### PR TITLE
修正第一章两处格式错误

### DIFF
--- a/src/hello/print/print_debug.md
+++ b/src/hello/print/print_debug.md
@@ -1,10 +1,10 @@
-# 调试（debug）
+# 调试（Debug）
 
 所有的类型，若想用 `std::fmt` 的格式化 `trait` 打印出来，都要求实现这个
  `trait`。自动的实现只为一些类型提供，比如 `std` 库中的类型。所有其他类型
 都**必须**手动实现。
 
-`fmt::Debug` 这个 `trait` 使这项工作变得相当简单。所有类型都能推导（derive，即自
+`fmt::Debug` 这个 `trait` 使这项工作变得相当简单。所有类型都能推导（`derive`，即自
 动创建）`fmt::Debug` 的实现。但是 `fmt::Display` 需要手动实现。
 
 ```rust

--- a/src/hello/print/print_display.md
+++ b/src/hello/print/print_display.md
@@ -1,4 +1,4 @@
-# 显示（display）
+# 显示（Display）
 
 `fmt::Debug` 通常看起来不太简洁，因此自定义输出的外观经常是更可取的。这需要通过
 手动实现 [`fmt::Display`][fmt] 来做到。`fmt::Display` 采用 `{}` 标记。实现方式看
@@ -23,7 +23,7 @@ impl fmt::Display for Structure {
 }
 ```
 
-`fmt::display` 的效果可能比 `fmt::Debug` 简洁，但对于 `std` 库来说，这就有一个问
+`fmt::Display` 的效果可能比 `fmt::Debug` 简洁，但对于 `std` 库来说，这就有一个问
 题。模棱两可的类型该如何显示呢？举个例子，假设标准库对所有的 `Vec<T>` 都实现了同
 一种输出样式，那么它应该是哪种样式？下面两种中的一种吗？
 


### PR DESCRIPTION
如题，修正第一章两处格式错误：

 * 依照英文原文及 Rust 语法，修改三处 Display 和 Debug 的拼写。
 * 依照英文原文，为 print_debug.md 中一处 `derive` 加上反引号。