### PR TITLE
fix broken link at tuples.md

### DIFF
--- a/src/primitives/tuples.md
+++ b/src/primitives/tuples.md
@@ -90,4 +90,4 @@ fn main() {
      ( 1.2 2.2 )
      ```
 
-[print_display]: ./hello/print/print_display.html
+[print_display]: ../hello/print/print_display.html


### PR DESCRIPTION
我发现在链接 https://rustwiki.org/zh-CN/rust-by-example/primitives/tuples.html#%E5%8A%A8%E6%89%8B%E8%AF%95%E4%B8%80%E8%AF%95
，动手试一试中有一个链接是错误的，路径应该是../hello/print/print_display.html