### PR TITLE
fix broken link compare with rust-by-example

### DIFF
--- a/src/attribute.md
+++ b/src/attribute.md
@@ -30,6 +30,6 @@
             value4, value5)]
 ```
 
-[cfg]: ./attribute/cfg.html
-[crate]: ./attribute/crate.html
+[cfg]: ./attribute/cfg.md
+[crate]: ./attribute/crate.md
 [lint]: https://en.wikipedia.org/wiki/Lint_%28software%29

--- a/src/attribute/cfg.md
+++ b/src/attribute/cfg.md
@@ -37,5 +37,5 @@ fn main() {
 [引用][ref], [`cfg!`][cfg], 和 [宏][macros].
 
 [cfg]: http://doc.rust-lang.org/std/macro.cfg!.html
-[macros]: ./macros.html
+[macros]: ../macros.html
 [ref]: http://doc.rust-lang.org/reference.html#conditional-compilation

--- a/src/compatibility.md
+++ b/src/compatibility.md
@@ -2,4 +2,4 @@
 
 Rust 语言正在快速发展，因此尽管努力确保尽可能向前兼容，但仍可能出现某些兼容性问题。
 
-* [原始标识符](compatibility/raw_identifiers.html)
+* [原始标识符](compatibility/raw_identifiers.md)

--- a/src/conversion/string.md
+++ b/src/conversion/string.md
@@ -44,5 +44,7 @@ fn main() {
 ```
 
 [`ToString`]: https://doc.rust-lang.org/std/string/trait.ToString.html
+[Display]: https://doc.rust-lang.org/std/fmt/trait.Display.html
+[print]: ../hello/print.md
 [`parse`]: https://doc.rust-lang.org/std/primitive.str.html#method.parse
 [`FromStr`]: https://doc.rust-lang.org/std/str/trait.FromStr.html

--- a/src/crates/lib.md
+++ b/src/crates/lib.md
@@ -27,4 +27,4 @@ library.rlib
 默认情况下，库会使用 crate 文件的名字，前面加上 “lib” 前缀，但这个默认名称可以
 使用 [`crate_name` 属性][crate-name] 覆盖。
 
-[crate-name]: ./attribute/crate.html
+[crate-name]: ../attribute/crate.html

--- a/src/custom_types/constants.md
+++ b/src/custom_types/constants.md
@@ -41,4 +41,4 @@ fn main() {
 https://github.com/rust-lang/rfcs/blob/master/text/0246-const-vs-static.md),
 [`'static` 生命周期][static]
 
-[static]: ./scope/lifetime/static_lifetime.html
+[static]: ../scope/lifetime/static_lifetime.html

--- a/src/custom_types/enum.md
+++ b/src/custom_types/enum.md
@@ -56,8 +56,8 @@ fn main() {
 
 [`attributes`][attributes], [`match`][match], [`fn`][fn], 和 [`String`][str]
 
-[attributes]: ./attribute.html
+[attributes]: ../attribute.html
 [c_struct]: http://en.wikipedia.org/wiki/Struct_(C_programming_language)
-[match]: ./flow_control/match.html
-[fn]: ./fn.html
-[str]: ./std/str.html
+[match]: ../flow_control/match.html
+[fn]: ../fn.html
+[str]: ../std/str.html

--- a/src/custom_types/enum/testcase_linked_list.md
+++ b/src/custom_types/enum/testcase_linked_list.md
@@ -75,5 +75,5 @@ fn main() {
 
 [`Box`][box] 和 [方法][methods]
 
-[box]: ./std/box.html
-[methods]: ./fn/methods.html
+[box]: ../std/box.html
+[methods]: ../fn/methods.html

--- a/src/custom_types/structs.md
+++ b/src/custom_types/structs.md
@@ -89,6 +89,6 @@ fn main() {
 
 [`attributes`][attributes] 和 [解构][destructuring]
 
-[attributes]: ./attribute.html
+[attributes]: ../attribute.html
 [c_struct]: http://en.wikipedia.org/wiki/Struct_(C_programming_language)
-[destructuring]: ./flow_control/match/destructuring.html
+[destructuring]: ../flow_control/match/destructuring.html

--- a/src/error/multiple_error_types/option_result.md
+++ b/src/error/multiple_error_types/option_result.md
@@ -54,4 +54,4 @@ fn main() {
 }
 ```
 
-[enter_question_mark]: error/result/enter_question_mark.html
+[enter_question_mark]: ../result/enter_question_mark.html

--- a/src/error/multiple_error_types/wrap_error.md
+++ b/src/error/multiple_error_types/wrap_error.md
@@ -89,4 +89,4 @@ fn main() {
 
 [from]: https://doc.rust-lang.org/std/convert/trait.From.html
 [q_mark]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#the--operator
-[enums]: custom_types/enum.html
+[enums]: ../../custom_types/enum.html

--- a/src/error/option_unwrap.md
+++ b/src/error/option_unwrap.md
@@ -60,4 +60,4 @@ fn main() {
 }
 ```
 
-[expect]: http://doc.rust-lang.org/std/option/enum.Option.html#method.expect
+[expect]: https://doc.rust-lang.org/std/option/enum.Option.html#method.expect

--- a/src/error/option_unwrap/and_then.md
+++ b/src/error/option_unwrap/and_then.md
@@ -71,6 +71,6 @@ fn main() {
 
 [闭包][closures]，[`Option::map()`][map], 和 [`Option::and_then()`][and_then]
 
-[closures]: ./fn/closures.html
+[closures]: ../../fn/closures.md
 [map]: http://doc.rust-lang.org/std/option/enum.Option.html#method.map
 [and_then]: http://doc.rust-lang.org/std/option/enum.Option.html#method.and_then

--- a/src/error/option_unwrap/map.md
+++ b/src/error/option_unwrap/map.md
@@ -76,6 +76,6 @@ fn main() {
 [闭包][closures], [`Option`][option], 和 [`Option::map()`][map]
 
 [combinators]: https://doc.rust-lang.org/book/glossary.html#combinators
-[closures]: ./fn/closures.html
-[option]: http://doc.rust-lang.org/std/option/enum.Option.html
-[map]: http://doc.rust-lang.org/std/option/enum.Option.html#method.map
+[closures]: ../../fn/closures.md
+[option]: https://doc.rust-lang.org/std/option/enum.Option.html
+[map]: https://doc.rust-lang.org/std/option/enum.Option.html#method.map

--- a/src/error/result.md
+++ b/src/error/result.md
@@ -41,6 +41,8 @@ fn main() {
 
 为了改善错误消息的质量，我们应该更具体地了解返回类型并考虑显式地处理错误。
 
-[option]: http://doc.rust-lang.org/std/option/enum.Option.html
-[result]: http://doc.rust-lang.org/std/result/enum.Result.html
+[option]: https://doc.rust-lang.org/std/option/enum.Option.html
+[result]: https://doc.rust-lang.org/std/result/enum.Result.html
 [parse]: https://doc.rust-lang.org/std/primitive.str.html#method.parse
+[`Debug`]: https://doc.rust-lang.org/std/fmt/trait.Debug.html
+[the following section]: result/early_returns.md

--- a/src/error/result/enter_question_mark.md
+++ b/src/error/result/enter_question_mark.md
@@ -66,4 +66,4 @@ fn main() {
 
 [^†]: 更多细节请看[`?` 的更多用法][re_enter_?]。
 
-[re_enter_?]: error/multiple_error_types/reenter_question_mark.html
+[re_enter_?]: ../multiple_error_types/reenter_question_mark.md

--- a/src/error/result/result_alias.md
+++ b/src/error/result/result_alias.md
@@ -40,6 +40,5 @@ fn main() {
 
 [`Result`][result] 和 [`io::Result`][io_result]
 
-[typealias]: ./cast/alias.html
-[result]: http://doc.rust-lang.org/std/result/enum.Result.html
-[io_result]: http://doc.rust-lang.org/std/io/type.Result.html
+[typealias]: ../../types/alias.md
+[io_result]: https://doc.rust-lang.org/std/io/type.Result.html

--- a/src/error/result/result_map.md
+++ b/src/error/result/result_map.md
@@ -98,7 +98,7 @@ fn main() {
 ```
 
 [parse]: https://doc.rust-lang.org/std/primitive.str.html#method.parse
-[from_str]: http://doc.rust-lang.org/std/str/trait.FromStr.html
-[i32]: http://doc.rust-lang.org/std/primitive.i32.html
-[parse_int_error]: http://doc.rust-lang.org/std/num/struct.ParseIntError.html
-[result]: http://doc.rust-lang.org/std/result/enum.Result.html
+[from_str]: https://doc.rust-lang.org/std/str/trait.FromStr.html
+[i32]: https://doc.rust-lang.org/std/primitive.i32.html
+[parse_int_error]: https://doc.rust-lang.org/std/num/struct.ParseIntError.html
+[result]: https://doc.rust-lang.org/std/result/enum.Result.html

--- a/src/primitives.md
+++ b/src/primitives.md
@@ -57,8 +57,8 @@ fn main() {
 
 [`std` 库][std]、[`mut`][mut]、[类型推断][inference] 和[变量掩蔽](shadowing)。
 
-[std]: http://doc.rust-lang.org/std/
-[mut]: https://rustbyexample.com/variable_bindings/mut.html
-[inference]: https://rustbyexample.com/types/inference.html
-[shadowing]: https://rustbyexample.com/variable_bindings/scope.html
+[std]: https://doc.rust-lang.org/std/
+[mut]: variable_bindings/mut.md
+[inference]: types/inference.md
+[shadowing]: variable_bindings/scope.md
 

--- a/src/std.md
+++ b/src/std.md
@@ -14,4 +14,4 @@
 [原生类型][primitives] 和 [标准库][std]
 
 [primitives]: ./primitives.html
-[std]: http://doc.rust-lang.org/std/
+[std]: https://doc.rust-lang.org/std/

--- a/src/std_misc.md
+++ b/src/std_misc.md
@@ -13,4 +13,4 @@
 [原生类型][primitives] 和 [标准库类型][std]
 
 [primitives]: ./primitives.html
-[std]: http://doc.rust-lang.org/std/
+[std]: https://doc.rust-lang.org/std/

--- a/src/types.md
+++ b/src/types.md
@@ -6,7 +6,7 @@ Rust 提供了多种机制，用于改变或定义原生类型和用户定义类
 * 使用[类型推断][type inference]（type inference）。
 * 给类型[取别名][Aliasing]（alias）。
 
-[Casting]: types/cast.html
-[literals]: types/literals.html
-[type inference]: types/inference.html
-[Aliasing]: types/alias.html
+[Casting]: types/cast.md
+[literals]: types/literals.md
+[type inference]: types/inference.md
+[Aliasing]: types/alias.md

--- a/src/types/alias.md
+++ b/src/types/alias.md
@@ -32,4 +32,4 @@ fn main() {
 
 ### See also:
 
-[属性](attribute.html)
+[Attributes](../attribute.md)

--- a/src/types/literals.md
+++ b/src/types/literals.md
@@ -35,6 +35,6 @@ fn main() {
   在 `mem` 模块中定义的，而 `mem` 模块又是在 `std` **crate** 中定义的。更多细节
   请看[模块][mod]和[crate][crate].
 
-[borrow]: scope/borrow.html
-[mod]: mod.html
-[crate]: crates.html
+[borrow]: ../scope/borrow.md
+[mod]: ../mod.md
+[crate]: ../crates.md

--- a/src/unsafe.md
+++ b/src/unsafe.md
@@ -53,5 +53,5 @@ fn main() {
 数据类型，我们**必须**满足这一假设，否则程序的行为是未定义的（undefined），于是
 我们就不能预测会发生些什么了。
 
-[unsafe]: https://doc.rust-lang.org/book/second-edition/ch19-01-unsafe-rust.html
+[unsafe]: https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html
 [`std::slice::from_raw_parts`]: https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html


### PR DESCRIPTION
在https://rustwiki.org/zh-CN/rust-by-example/custom_types/enum/testcase_linked_list.html 中末尾有两个链接404了，我试图修复了他
you can merge before rebase it
P.S. 我根据调整后的rust-by-example层级目录调整了里面的链接，应该是支持md格式自动转换html的