### PR TITLE
fix the docs refer

### DIFF
--- a/src/hello/comment.md
+++ b/src/hello/comment.md
@@ -40,4 +40,4 @@ fn main() {
 
 [文档注释][docs]
 
-[docs]: ./meta/doc.html
+[docs]: /meta/doc.html

--- a/src/hello/comment.md
+++ b/src/hello/comment.md
@@ -40,4 +40,4 @@ fn main() {
 
 [文档注释][docs]
 
-[docs]: /meta/doc.html
+[docs]: ../meta/doc.html


### PR DESCRIPTION
`文档注释`的原链接指向错误的`URI`：`http://localhost:3000/hello/meta/doc.html`,  修改`comment.md`使之指向正确的链接地址