### PR TITLE
chore: enable section-folding of table of content

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -13,3 +13,6 @@ edit-url-template = "https://github.com/rust-lang-cn/rust-by-example-cn/edit/mas
 [output.html.playpen]
 editable = true
 editor = "ace"
+
+[output.html.fold]
+enable = true


### PR DESCRIPTION
## Motivation

- The section-folding configuration has landed in mdBook. Enable this would make the sidebar a little bit clear.
![image](https://user-images.githubusercontent.com/38807139/132187093-981fbf88-75c9-4da3-8fc6-55a35023d8dc.png)
