### PR TITLE
fix broken link at enum.md

### DIFF
--- a/src/custom_types/enum.md
+++ b/src/custom_types/enum.md
@@ -100,4 +100,5 @@ impl VeryVerboseEnumOfThingsToDoWithNumbers {
 [match]: ../flow_control/match.md
 [fn]: ../fn.md
 [str]: ../std/str.md
+[aliasreport]: https://github.com/rust-lang/rust/pull/61682/#issuecomment-502472847
 [type_alias_rfc]: https://rust-lang.github.io/rfcs/2338-type-alias-enum-variants.html


### PR DESCRIPTION
添加第103行：`[aliasreport]: https://github.com/rust-lang/rust/pull/61682/#issuecomment-502472847`。
原文中有这一行，但译文中缺少这一行，导致第92行的`[stabilization report][aliasreport]`无法正常显示。