### PR TITLE
Fix typo in bounds.md

### DIFF
--- a/src/generics/bounds.md
+++ b/src/generics/bounds.md
@@ -23,7 +23,7 @@ let s = S(vec![1]);
 
 约束的另一个作用是泛型的实例可以访问作为约束的 trait 的方法。例如：
 
-```rust,editalbe
+```rust,editable
 // 这个 trait 用来实现打印标记：`{:?}`。
 use std::fmt::Debug;
 


### PR DESCRIPTION
第26行的`editable`被误拼为`editalbe`导致该段代码无法被编辑并进行试一试的练习。