### PR TITLE
fix: remove the undeleted original text

### DIFF
--- a/src/trait/drop.md
+++ b/src/trait/drop.md
@@ -7,7 +7,6 @@
 资源的类型。`Drop` trait 也可以为任何自定义数据类型手动实现。
 
 下面示例给 `drop` 函数增加了打印到控制台的功能，用于宣布它在什么时候被调用。
-when it is called.）
 
 ```rust,editable
 struct Droppable {


### PR DESCRIPTION
第10行多出了原文中的`when it is called.）`，但这句话在译文中没有实际意义。