### PR TITLE
Update string.md

### DIFF
--- a/src/conversion/string.md
+++ b/src/conversion/string.md
@@ -4,6 +4,27 @@
 
 要把任何类型转换成 `String`，只需要实现那个类型的 [`ToString`] trait。然而不要直接这么做，您应该实现[`fmt::Display`][Display] trait，它会自动提供 [`ToString`]，并且还可以用来打印类型，就像 [`print!`][print] 一节中讨论的那样。
 
+
+```rust,editable
+use std::fmt;
+
+struct Circle {
+    radius: i32
+}
+
+impl fmt::Display for Circle {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Circle of radius {}", self.radius)
+    }
+}
+
+fn main() {
+    let circle = Circle { radius: 6 };
+    println!("{}", circle.to_string());
+}
+```
+
+译注：一个实现`ToString`的例子
 ```rust,editable
 use std::string::ToString;
 

--- a/src/conversion/string.md
+++ b/src/conversion/string.md
@@ -24,7 +24,8 @@ fn main() {
 }
 ```
 
-译注：一个实现`ToString`的例子
+译注：一个实现 `ToString` 的例子
+
 ```rust,editable
 use std::string::ToString;
 


### PR DESCRIPTION
译文与例子不匹配。同时保留了 `ToString` 的实现。