### PR TITLE
Update iter_any.md

### DIFF
--- a/src/fn/closures/closure_examples/iter_any.md
+++ b/src/fn/closures/closure_examples/iter_any.md
@@ -32,9 +32,9 @@ fn main() {
     let array2 = [4, 5, 6];
 
     // 对数组的 `iter()` 举出 `&i32`。
-    println!("2 in array1: {}", array1.iter().any(|&x| x == 2));
-    // 对数组的 `into_iter()` 通常举出 `&i32`。
-    println!("2 in array2: {}", array2.iter().any(|&x| x == 2));
+    println!("2 in array1: {}", array1.iter()     .any(|&x| x == 2));
+    // 对数组的 `into_iter()` 举出 `i32`。
+    println!("2 in array2: {}", array2.into_iter().any(|x| x == 2));
 }
 ```
 


### PR DESCRIPTION
随原文仓库 [fc820babeddb1fcc09c87b3630ee97fe3e72d2ac](https://github.com/rust-lang/rust-by-example/commit/fc820babeddb1fcc09c87b3630ee97fe3e72d2ac) 进行了更新。

此处有明显错误， `into_iter()` 并不会 yield 一个引用类型。

